### PR TITLE
Update config.yml to have more meaningful names on the promotion type.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,10 +1,14 @@
 ---
   promotions:
-    autopkg:
+    "autopkg to testing":
+      promote_from:
+        - "autopkg"
       promote_to:
         - "testing"
       days_in_catalog: 3
-    testing:
+    "testing to production":
+      promote_from:
+        - "testing"
       promote_to:
         - "production"
       days_in_catalog: 7

--- a/munki-promoter.py
+++ b/munki-promoter.py
@@ -435,7 +435,15 @@ def prep_pkgsinfo_single_promotion(promote_to, promote_from, days, custom_items,
 def prep_item_for_promotion(item, promote_to, promote_from, days, custom_items, item_path):
 	changed_promote_to = False
 	try:
-		item_name = item["name"]
+
+		item_architecture = item.get("supported_architectures", [])
+
+		if item_architecture:
+			item_architecture = f" ({', '.join(item_architecture)})"
+		else:
+			item_architecture = ""
+
+		item_name = item["name"] + item_architecture
 		item_version = item["version"]
 		item_catalogs = item["catalogs"]
 	except Exception as e:


### PR DESCRIPTION
Update munki-promoter.py to also include the architecture when apps are promoted - tested this and it does apply to standard out, slack and also the markdown change log